### PR TITLE
feat: Implementa a camada de dados e ViewModel para Ponto Gastronomico

### DIFF
--- a/.idea/copilot.data.migration.agent.xml
+++ b/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask.xml
+++ b/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.edit.xml
+++ b/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/frontend-android/.idea/deploymentTargetSelector.xml
+++ b/frontend-android/.idea/deploymentTargetSelector.xml
@@ -2,16 +2,8 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="MainActivity">
+      <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-21T00:52:19.212906100Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\junin\.android\avd\Pixel_Tablet.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/frontend-android/app/src/main/java/com/wayads/data/model/PontoGastronomico.kt
+++ b/frontend-android/app/src/main/java/com/wayads/data/model/PontoGastronomico.kt
@@ -1,0 +1,14 @@
+package com.wayads.data.model
+
+// Representa um Ponto Gastronômico que vem da API
+data class PontoGastronomico(
+    val id: Long,
+    val nome: String,
+    val descricao: String,
+    val localizacao: String,
+    val imagemUrl: String?,
+    val categoria: String,
+    val fonte: String?,
+    val criadoEm: String?, // Datas podem vir como String da API
+    val atualizadoEm: String?
+)

--- a/frontend-android/app/src/main/java/com/wayads/data/network/ApiService.kt
+++ b/frontend-android/app/src/main/java/com/wayads/data/network/ApiService.kt
@@ -3,6 +3,7 @@ package com.wayads.data.network
 import com.wayads.data.model.Anuncio
 import com.wayads.data.model.MovieResponse
 import com.wayads.data.model.Noticia
+import com.wayads.data.model.PontoGastronomico
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -20,8 +21,8 @@ interface ApiService {
     @GET("entretenimento")
     suspend fun getEntretenimento(): List<Anuncio>
 
-    @GET("gastronomia")
-    suspend fun getGastronomia(): List<Anuncio>
+    @GET("v1/pontos-gastronomicos")
+    suspend fun getPontosGastronomicos(): List<PontoGastronomico>
 
     @GET("kids")
     suspend fun getKids(): List<Anuncio>

--- a/frontend-android/app/src/main/java/com/wayads/repository/PontoGastronomicoRepository.kt
+++ b/frontend-android/app/src/main/java/com/wayads/repository/PontoGastronomicoRepository.kt
@@ -1,0 +1,13 @@
+package com.wayads.repository
+
+import com.wayads.data.model.PontoGastronomico
+import com.wayads.data.network.ApiService
+import javax.inject.Inject
+
+class PontoGastronomicoRepository @Inject constructor(private val apiService: ApiService) {
+
+    suspend fun getPontosGastronomicos(): List<PontoGastronomico> {
+        return apiService.getPontosGastronomicos()
+    }
+
+}

--- a/frontend-android/app/src/main/java/com/wayads/ui/gastronomia/viewmodel/PontoGastronomicoViewModel.kt
+++ b/frontend-android/app/src/main/java/com/wayads/ui/gastronomia/viewmodel/PontoGastronomicoViewModel.kt
@@ -1,0 +1,32 @@
+package com.wayads.ui.gastronomia.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wayads.data.model.PontoGastronomico
+import com.wayads.repository.PontoGastronomicoRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PontoGastronomicoViewModel @Inject constructor(private val repository: PontoGastronomicoRepository) : ViewModel() {
+
+    private val _pontosGastronomicos = MutableStateFlow<List<PontoGastronomico>>(emptyList())
+    val pontosGastronomicos: StateFlow<List<PontoGastronomico>> = _pontosGastronomicos
+
+    init {
+        fetchPontosGastronomicos()
+    }
+
+    private fun fetchPontosGastronomicos() {
+        viewModelScope.launch {
+            try {
+                _pontosGastronomicos.value = repository.getPontosGastronomicos()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Este PR implementa a base para a funcionalidade de Ponto Gastronômico, alinhando com a refatoração feita no back-end.

**O que foi feito:**
- Criado o modelo de dados `PontoGastronomico.kt` para o front-end.
- Atualizado o `ApiService` para consumir o novo endpoint `/api/v1/pontos-gastronomicos`.
- Implementado o `PontoGastronomicoRepository` para buscar os dados.
- Criado o `PontoGastronomicoViewModel` para gerenciar o estado e fornecer os dados para a futura tela.

Com este PR, a lógica de busca e preparação de dados está pronta. O próximo passo é a implementação da `GastronomiaScreen`.